### PR TITLE
Clarify lead class discount language

### DIFF
--- a/src/CONFIG_FILES/membership.js
+++ b/src/CONFIG_FILES/membership.js
@@ -29,7 +29,7 @@ export const LEVELS = {
         outdoor education classes through the EMS School</li>
         <li>Discounted day passes during CRUX nights</li>
         <li>Free belay class at The Cliffs LIC during CRUX nights</li>
-        <li>50% off Sport Lead Basic class at The Cliffs LIC</li>
+        <li>50% off Sport Lead Basic class at The Cliffs LIC when organized through CRUX</li>
       </ul>
     ),
   },


### PR DESCRIPTION
This language clarification comes as the result of a new member who tried to access our 50% off discount directly through The Cliffs.